### PR TITLE
FreeCAD 1.0 compatibility

### DIFF
--- a/mod/constants.py
+++ b/mod/constants.py
@@ -6,7 +6,7 @@
 from mod.enums import FreeCADObjectType
 
 # APP Constants
-FREECAD_MIN_VERSION = "018"
+FREECAD_MIN_VERSION = "0.18"
 APP_NAME = "DesignSPHysics"
 DIVIDER = 1000
 LINE_END = "\n"

--- a/mod/freecad_tools.py
+++ b/mod/freecad_tools.py
@@ -42,7 +42,7 @@ def check_compatibility():
 
 def is_compatible_version():
     """ Checks if the current FreeCAD version is suitable for this macro. """
-    version_num = FreeCAD.Version()[0] + FreeCAD.Version()[1]
+    version_num = FreeCAD.Version()[0] + '.' + FreeCAD.Version()[1]
     if float(version_num) < float(FREECAD_MIN_VERSION):
         return False
     return True

--- a/mod/main.py
+++ b/mod/main.py
@@ -146,7 +146,12 @@ def boot():
 
     # Subscribe the FreeCAD Objects tree to the item selection change function.
     # This helps FreeCAD notify DesignSPHysics for the deleted and changed objects to get updated correctly.
-    fc_object_tree: QtGui.QTreeWidget = get_fc_main_window().findChildren(QtGui.QSplitter)[0].findChildren(QtGui.QTreeWidget)[0]
+    for fcm in get_fc_main_window().findChildren(QtGui.QSplitter):
+        tree_widgets = fcm.findChildren(QtGui.QTreeWidget)
+        if tree_widgets:  # Check if list not empty
+            fc_object_tree: QtGui.QTreeWidget = tree_widgets[0]
+            break
+
     fc_object_tree.itemSelectionChanged.connect(lambda p=properties_widget, d=designsphysics_dock: on_tree_item_selection_change(p, d))
     debug("Subscribing selection change monitor handler to freecad object tree item changed.")
 


### PR DESCRIPTION
This is fix for things breaking in FreeCAD 1.0, discussed here: https://github.com/DualSPHysics/DesignSPHysics/issues/218#issuecomment-2351518554

1. Version check with decimal point now.
2. The macro does not assume anymore that the first QtGui.QSplitter child of FreeCADGui.getMainWindow() is correct.