### PR TITLE
Enable smaller inter-particle distance values

### DIFF
--- a/mod/widgets/custom_widgets/size_input.py
+++ b/mod/widgets/custom_widgets/size_input.py
@@ -2,7 +2,7 @@ import re
 
 import FreeCAD
 
-from mod.constants import DEFAULT_MIN_WIDGET_WIDTH, DEFAULT_MAX_WIDGET_WIDTH,AUTO_UNITS_SELECT
+from mod.constants import DEFAULT_MIN_WIDGET_WIDTH, DEFAULT_MAX_WIDGET_WIDTH,AUTO_UNITS_SELECT,DEFAULT_DECIMALS
 from mod.tools.dialog_tools import warning_dialog
 from mod.tools.stdout_tools import debug
 from mod.widgets.custom_widgets.base_units_input import BaseUnitsInput
@@ -11,8 +11,8 @@ from mod.widgets.custom_widgets.base_units_input import BaseUnitsInput
 
 class SizeInput(BaseUnitsInput):
 
-    def __init__(self, min_val=-10e12,max_val=10e12,minwidth=DEFAULT_MIN_WIDGET_WIDTH, maxwidth=DEFAULT_MAX_WIDGET_WIDTH,parent=None,value=0):#maxwidth=45
-        super().__init__(min_val,max_val,minwidth,maxwidth,parent)
+    def __init__(self, min_val=-10e12,max_val=10e12,minwidth=DEFAULT_MIN_WIDGET_WIDTH, maxwidth=DEFAULT_MAX_WIDGET_WIDTH,parent=None,value=0,decimals=DEFAULT_DECIMALS):#maxwidth=45
+        super().__init__(min_val,max_val,minwidth,maxwidth,parent,decimals)
         # Initialize unit system
         # self.quantity_box.setUnit("m") #<Not needed
         self.setValue(value)

--- a/mod/widgets/dock/dock_dp_widget.py
+++ b/mod/widgets/dock/dock_dp_widget.py
@@ -26,7 +26,7 @@ class DockDPWidget(QtWidgets.QWidget):
         self.dp_label = QtWidgets.QLabel(__("Inter-particle distance: "))
         self.dp_label.setToolTip(__("Lower DP to have more particles in the case."))
 
-        self.dp_input = SizeInput()
+        self.dp_input = SizeInput(decimals=6)
         self.dp_input.setToolTip(__("Lower DP to have more particles in the case."))
         self.dp_input.setValue(Case.the().dp)
         self.dp_input.value_changed.connect(self.on_dp_changed)


### PR DESCRIPTION
## Summary
- Increased decimal precision for inter-particle distance input from default to 6 decimals
- Updated SizeInput widget to accept configurable decimal places
- Modified dock_dp_widget to use 6 decimal places for inter-particle distance

## Problem Solved
Previously, users could not set inter-particle distance values lower than 0.001. This change allows for much smaller values by increasing the number of decimal places displayed and accepted in the input field.

## Changes
- `mod/widgets/custom_widgets/size_input.py`: Added decimals parameter to SizeInput constructor
- `mod/widgets/dock/dock_dp_widget.py`: Set dp_input to use 6 decimal places

## Alternative Solution
Another approach would be to modify the DEFAULT_DECIMALS constant, but this would affect all other numeric inputs throughout the application. The current solution provides targeted precision only where needed.