### PR TITLE
FreeCAD 1.1 compatibility for DesignSPHysics 0.8.1

### DIFF
--- a/DesignSPHysics.FCMacro
+++ b/DesignSPHysics.FCMacro
@@ -9,9 +9,17 @@ import sys
 import os
 
 """ Disables some types of FreeCAD warnings """
-from PySide2.QtCore import qInstallMessageHandler, QtMsgType
+try:
+    from PySide6.QtCore import qInstallMessageHandler
+except ImportError:
+    from PySide2.QtCore import qInstallMessageHandler
+
 def customMessageHandler(type, context, message):
-    if "QWindowsWindow::setMouseGrabEnabled" not in message:
+    ignored_messages = (
+        "QWindowsWindow::setMouseGrabEnabled",
+        "QWindowsWindow::setGeometry: Unable to set geometry"
+    )
+    if not any(m in message for m in ignored_messages):
         print(message)
 qInstallMessageHandler(customMessageHandler)
 os.environ["QT_LOGGING_RULES"] = "*.debug=false;*.warning=false"
@@ -20,7 +28,9 @@ os.environ["QT_LOGGING_RULES"] = "*.debug=false;*.warning=false"
 import logging
 class IgnoreMouseGrabWarning(logging.Filter):
     def filter(self, record):
-        return "QWindowsWindow::setMouseGrabEnabled" not in record.getMessage()
+        msg = record.getMessage()
+        return "QWindowsWindow::setMouseGrabEnabled" not in msg and \
+            "QWindowsWindow::setGeometry: Unable to set geometry" not in msg
 logger = logging.getLogger()
 logger.addFilter(IgnoreMouseGrabWarning)
 # --------------------

--- a/mod/main.py
+++ b/mod/main.py
@@ -12,7 +12,7 @@ from urllib.request import urlopen
 
 import FreeCADGui
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 
 from mod.constants import APP_NAME, VERSION, REVISION, DEFAULT_WORKBENCH, GITHUB_MASTER_CONSTANTS_URL, \
     DAMPING_GROUP_NAME, SIMULATION_DOMAIN_NAME

--- a/mod/tools/dialog_tools.py
+++ b/mod/tools/dialog_tools.py
@@ -3,9 +3,9 @@
 """DesignSPHysics Dialog Tools.
 
 Contains general use standard dialogs. """
-from PySide2.QtWidgets import QDialog
+from mod.tools.qt_compat import QDialog
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 
 from mod.tools.translation_tools import __
 

--- a/mod/tools/executable_tools.py
+++ b/mod/tools/executable_tools.py
@@ -9,7 +9,7 @@ from sys import platform
 import json
 
 # from PySide2import QtCore
-from PySide2 import QtCore
+from mod.tools.qt_compat import QtCore
 
 import FreeCADGui
 

--- a/mod/tools/freecad_tools.py
+++ b/mod/tools/freecad_tools.py
@@ -11,7 +11,7 @@ import FreeCADGui
 import Draft
 import Part
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 
 from mod.dataobjects.gauges.flow_gauge import FlowGauge
 from mod.dataobjects.gauges.gauge_base import Gauge

--- a/mod/tools/gui_tools.py
+++ b/mod/tools/gui_tools.py
@@ -9,7 +9,7 @@ operations in DesignSPHysics.
 
 import os
 
-from PySide2 import QtWidgets,QtGui
+from mod.tools.qt_compat import QtWidgets,QtGui
 
 
 def h_line_generator() -> QtWidgets.QFrame:

--- a/mod/tools/main_loop_tools.py
+++ b/mod/tools/main_loop_tools.py
@@ -1,7 +1,7 @@
 import time
 import sys
-from PySide2.QtCore import Signal, Slot, QObject
-from PySide2 import QtCore
+from mod.tools.qt_compat import Signal, Slot, QObject
+from mod.tools.qt_compat import QtCore
 
 from mod.constants import DIVIDER, CASE_LIMITS_OBJ_NAME, GAUGES_GROUP_NAME, VRES_BOXES_GROUP_NAME, \
     IO_ZONES_GROUP_NAME, OUTFILTERS_GROUP_NAME, VARIABLES_SHEET_NAME, DAMPING_GROUP_NAME, SIMULATION_DOMAIN_NAME, HELPER_FOLDER_GROUP_NAME

--- a/mod/tools/numvalidator_tools.py
+++ b/mod/tools/numvalidator_tools.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """ General number validators to be used in DesingSPHysics."""
 
-from PySide2 import QtCore,QtGui
+from mod.tools.qt_compat import QtCore,QtGui
 
 class FloatValidator(QtGui.QValidator):
     """ Validates float numbers """

--- a/mod/tools/post_processing_tools.py
+++ b/mod/tools/post_processing_tools.py
@@ -4,7 +4,7 @@
 import os
 import subprocess
 
-from PySide2 import QtCore
+from mod.tools.qt_compat import QtCore
 from mod.tools.script_tools import generate_ext_script
 
 from mod.tools.translation_tools import __

--- a/mod/tools/qt_compat.py
+++ b/mod/tools/qt_compat.py
@@ -1,0 +1,57 @@
+"""Qt compatibility helpers for FreeCAD environments.
+
+This module prefers PySide6 (used by newer FreeCAD versions) and
+falls back to PySide2 for older releases.
+"""
+
+try:
+    from PySide6 import QtCore, QtGui, QtWidgets  # type: ignore
+    from PySide6.QtCore import QObject, Signal, Slot  # type: ignore
+    from PySide6.QtGui import QAction, QValidator  # type: ignore
+    from PySide6.QtWidgets import QDialog, QDoubleSpinBox, QHBoxLayout, QWidget  # type: ignore
+except ImportError:
+    from mod.tools.qt_compat import QtCore, QtGui, QtWidgets  # type: ignore
+    from PySide2.QtCore import QObject, Signal, Slot  # type: ignore
+    from mod.tools.qt_compat import QValidator  # type: ignore
+    from mod.tools.qt_compat import QAction, QDialog, QDoubleSpinBox, QHBoxLayout, QWidget  # type: ignore
+
+
+# Qt6 removed several Qt5 aliases commonly used by legacy plugins.
+if not hasattr(QtWidgets.QHeaderView, "setResizeMode") and hasattr(QtWidgets.QHeaderView, "setSectionResizeMode"):
+    def _set_resize_mode(self, *args):
+        return self.setSectionResizeMode(*args)
+
+    try:
+        QtWidgets.QHeaderView.setResizeMode = _set_resize_mode  # type: ignore[attr-defined]
+    except (AttributeError, TypeError):
+        pass
+
+
+if not hasattr(QtWidgets.QDialog, "exec_") and hasattr(QtWidgets.QDialog, "exec"):
+    try:
+        QtWidgets.QDialog.exec_ = QtWidgets.QDialog.exec  # type: ignore[attr-defined]
+    except (AttributeError, TypeError):
+        pass
+
+
+if hasattr(QtWidgets, "QApplication") and not hasattr(QtWidgets.QApplication, "exec_") and hasattr(QtWidgets.QApplication, "exec"):
+    try:
+        QtWidgets.QApplication.exec_ = QtWidgets.QApplication.exec  # type: ignore[attr-defined]
+    except (AttributeError, TypeError):
+        pass
+
+
+__all__ = [
+    "QtCore",
+    "QtGui",
+    "QtWidgets",
+    "Signal",
+    "Slot",
+    "QObject",
+    "QAction",
+    "QDialog",
+    "QDoubleSpinBox",
+    "QHBoxLayout",
+    "QValidator",
+    "QWidget",
+]

--- a/mod/widgets/custom_widgets/acceleration_input.py
+++ b/mod/widgets/custom_widgets/acceleration_input.py
@@ -1,6 +1,6 @@
 import re
 
-from PySide2 import QtWidgets, QtCore
+from mod.tools.qt_compat import QtWidgets, QtCore
 
 import FreeCADGui
 import FreeCAD

--- a/mod/widgets/custom_widgets/base_units_input.py
+++ b/mod/widgets/custom_widgets/base_units_input.py
@@ -1,6 +1,6 @@
 import re
 
-from PySide2 import QtWidgets, QtCore
+from mod.tools.qt_compat import QtWidgets, QtCore
 
 import FreeCADGui
 import FreeCAD

--- a/mod/widgets/custom_widgets/error_report_dialog.py
+++ b/mod/widgets/custom_widgets/error_report_dialog.py
@@ -6,7 +6,7 @@ import webbrowser
 from platform import platform
 
 import FreeCAD
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 
 from mod.tools.gui_tools import h_line_generator
 

--- a/mod/widgets/custom_widgets/focusable_combo_box.py
+++ b/mod/widgets/custom_widgets/focusable_combo_box.py
@@ -3,7 +3,7 @@
 """ DesignSPHysics Focusable ComboBox implementation. """
 
 from mod.constants import DEFAULT_MIN_WIDGET_WIDTH, DEFAULT_MAX_WIDGET_WIDTH
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 
 
 class FocusableComboBox(QtWidgets.QComboBox):

--- a/mod/widgets/custom_widgets/information_dialog.py
+++ b/mod/widgets/custom_widgets/information_dialog.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics General Information Dialog"""
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 
 
 from mod.enums import InformationDetailsMode

--- a/mod/widgets/custom_widgets/int_value_input.py
+++ b/mod/widgets/custom_widgets/int_value_input.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets, QtCore
+from mod.tools.qt_compat import QtWidgets, QtCore
 
 import FreeCADGui
 import FreeCAD

--- a/mod/widgets/custom_widgets/mk_select_input_with_names.py
+++ b/mod/widgets/custom_widgets/mk_select_input_with_names.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3.7
 # -*- coding: utf-8 -*-
 """DesignSPHysics MK selector widget"""
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.constants import DEFAULT_MIN_WIDGET_WIDTH, DEFAULT_MAX_WIDGET_WIDTH
 from mod.dataobjects.case import Case
 from mod.enums import ObjectType

--- a/mod/widgets/custom_widgets/time_input.py
+++ b/mod/widgets/custom_widgets/time_input.py
@@ -1,6 +1,6 @@
 import re
 
-from PySide2 import QtWidgets, QtCore
+from mod.tools.qt_compat import QtWidgets, QtCore
 
 import FreeCADGui
 import FreeCAD

--- a/mod/widgets/custom_widgets/unit_spin_box.py
+++ b/mod/widgets/custom_widgets/unit_spin_box.py
@@ -1,5 +1,5 @@
-from PySide2.QtWidgets import QDoubleSpinBox
-from PySide2.QtGui import QValidator
+from mod.tools.qt_compat import QDoubleSpinBox
+from mod.tools.qt_compat import QValidator
 
 from mod.tools.stdout_tools import debug
 

--- a/mod/widgets/custom_widgets/value_input.py
+++ b/mod/widgets/custom_widgets/value_input.py
@@ -1,6 +1,6 @@
 import re
 
-from PySide2 import QtWidgets, QtCore
+from mod.tools.qt_compat import QtWidgets, QtCore
 
 import FreeCADGui
 

--- a/mod/widgets/custom_widgets/velocity_input.py
+++ b/mod/widgets/custom_widgets/velocity_input.py
@@ -1,6 +1,6 @@
 import re
 
-from PySide2 import QtWidgets, QtCore
+from mod.tools.qt_compat import QtWidgets, QtCore
 
 import FreeCADGui
 import FreeCAD

--- a/mod/widgets/designsphysics_dock.py
+++ b/mod/widgets/designsphysics_dock.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 """Main DesignSPHysics Dock Widget """
 
-from PySide2 import QtWidgets, QtCore
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtWidgets, QtCore
+from mod.tools.qt_compat import QtCore, QtWidgets
 
 from mod.constants import MAIN_WIDGET_INTERNAL_NAME, APP_NAME, VERSION, VER_DATE
 from mod.dataobjects.case import Case

--- a/mod/widgets/dock/dock_configuration_widget.py
+++ b/mod/widgets/dock/dock_configuration_widget.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Dock Configuration Widget. """
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 
 
 from mod.dataobjects.case import Case

--- a/mod/widgets/dock/dock_dp_widget.py
+++ b/mod/widgets/dock/dock_dp_widget.py
@@ -3,7 +3,7 @@
 """DesignSPHysics Dock DP Intro Widget """
 
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 
 from mod.tools.translation_tools import __
 

--- a/mod/widgets/dock/dock_logo_widget.py
+++ b/mod/widgets/dock/dock_logo_widget.py
@@ -5,7 +5,7 @@
 import webbrowser
 
 
-from PySide2 import QtWidgets,QtGui
+from mod.tools.qt_compat import QtWidgets,QtGui
 
 
 from mod.enums import HelpURL
@@ -24,7 +24,7 @@ class DockLogoWidget(QtWidgets.QWidget):
         self.main_layout.setContentsMargins(0, 0, 0, 0)
 
         self.logo_label = QtWidgets.QLabel()
-        self.logo_label.setPixmap(get_icon(file_name="logo.png", return_only_path=True))
+        self.logo_label.setPixmap(QtGui.QPixmap(get_icon(file_name="logo.png", return_only_path=True)))
 
         self.help_button = QtWidgets.QPushButton("Help")
         self.help_button.setToolTip(__("Push this button to open a browser with help\non how to use this tool."))

--- a/mod/widgets/dock/dock_object_list_table_widget.py
+++ b/mod/widgets/dock/dock_object_list_table_widget.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Object List Table Widget."""
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.constants import CASE_LIMITS_OBJ_NAME
 from mod.dataobjects.case import Case
 from mod.tools.freecad_tools import get_fc_object
@@ -25,7 +25,7 @@ class DockObjectListTableWidget(QtWidgets.QWidget):
         self.objectlist_table = QtWidgets.QTableWidget(0, 1)
         self.objectlist_table.verticalHeader().setVisible(False)
         self.objectlist_table.horizontalHeader().setVisible(False)
-        self.objectlist_table.horizontalHeader().setResizeMode(0, QtWidgets.QHeaderView.Stretch)
+        self.objectlist_table.horizontalHeader().setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
 
         self.objectlist_layout.addWidget(self.objectlist_label)
         self.objectlist_layout.addWidget(self.objectlist_table)

--- a/mod/widgets/dock/dock_post_processing_widget.py
+++ b/mod/widgets/dock/dock_post_processing_widget.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Dock Post Processing Widget """
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.tools.translation_tools import __
 from mod.widgets.dock.postprocessing.computeforces_dialog import ComputeForcesDialog
 from mod.widgets.dock.postprocessing.floatinginfo_dialog import FloatingInfoDialog

--- a/mod/widgets/dock/dock_pre_processing_widget.py
+++ b/mod/widgets/dock/dock_pre_processing_widget.py
@@ -7,8 +7,8 @@ from traceback import print_exc
 import FreeCADGui
 
 
-from PySide2 import QtCore, QtWidgets,QtGui
-from PySide2.QtWidgets import QAction
+from mod.tools.qt_compat import QtCore, QtWidgets,QtGui
+from mod.tools.qt_compat import QAction
 
 from mod.appmode import AppMode
 from mod.constants import CASE_LIMITS_OBJ_NAME, CASE_LIMITS_2D_LABEL, CASE_LIMITS_3D_LABEL, WIDTH_2D

--- a/mod/widgets/dock/dock_simulation_widget.py
+++ b/mod/widgets/dock/dock_simulation_widget.py
@@ -6,8 +6,8 @@ import os
 import re
 from sys import platform
 
-from PySide2 import QtWidgets, QtCore
-from PySide2.QtWidgets import QAction
+from mod.tools.qt_compat import QtWidgets, QtCore
+from mod.tools.qt_compat import QAction
 
 from mod.dataobjects.case import Case
 from mod.dataobjects.configuration.application_settings import ApplicationSettings

--- a/mod/widgets/dock/dock_widgets/add_bathymetry_dialog.py
+++ b/mod/widgets/dock/dock_widgets/add_bathymetry_dialog.py
@@ -6,7 +6,7 @@ from os.path import dirname
 from tempfile import gettempdir
 from uuid import uuid4
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.case import Case
 from mod.tools.dialog_tools import error_dialog, WaitDialog, warning_dialog
 from mod.tools.executable_tools import ensure_process_is_executable_or_fail

--- a/mod/widgets/dock/dock_widgets/add_geo_dialog.py
+++ b/mod/widgets/dock/dock_widgets/add_geo_dialog.py
@@ -6,7 +6,7 @@ from os.path import dirname
 from tempfile import gettempdir
 from uuid import uuid4
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.case import Case
 from mod.tools.dialog_tools import error_dialog, WaitDialog, warning_dialog
 from mod.tools.executable_tools import ensure_process_is_executable_or_fail

--- a/mod/widgets/dock/dock_widgets/case_summary.py
+++ b/mod/widgets/dock/dock_widgets/case_summary.py
@@ -3,7 +3,7 @@
 """ DesignsSPHysics Case Summary Dialog """
 
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 
 from mod.constants import CASE_LIMITS_OBJ_NAME, MKFLUID_LIMIT, MKFLUID_OFFSET
 from mod.dataobjects.case import Case

--- a/mod/widgets/dock/dock_widgets/constants_dialog.py
+++ b/mod/widgets/dock/dock_widgets/constants_dialog.py
@@ -3,7 +3,7 @@
 """DesignSPHysics Constants Configuration Dialog."""
 
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.case import Case
 from mod.dataobjects.configuration.application_settings import ApplicationSettings
 from mod.enums import HelpText

--- a/mod/widgets/dock/dock_widgets/execution_parameters_dialog.py
+++ b/mod/widgets/dock/dock_widgets/execution_parameters_dialog.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Execution Parameters Configuration Dialog."""
 import FreeCADGui
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 
 from mod.dataobjects.configuration.application_settings import ApplicationSettings
 from mod.tools.dialog_tools import warning_dialog

--- a/mod/widgets/dock/dock_widgets/feature_support_dialog.py
+++ b/mod/widgets/dock/dock_widgets/feature_support_dialog.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Setup Plugin Dialog """
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 
 from mod.tools.stdout_tools import debug
 from mod.tools.translation_tools import __

--- a/mod/widgets/dock/dock_widgets/gencase_completed_dialog.py
+++ b/mod/widgets/dock/dock_widgets/gencase_completed_dialog.py
@@ -6,7 +6,7 @@ import subprocess
 from os import listdir
 from os.path import isfile, join
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.tools.stdout_tools import debug
 
 from mod.tools.translation_tools import __

--- a/mod/widgets/dock/dock_widgets/mode_2d_config_dialog.py
+++ b/mod/widgets/dock/dock_widgets/mode_2d_config_dialog.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """ 2D Mode Configuration Dialog. """
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 
 from mod.appmode import AppMode
 from mod.tools.translation_tools import __

--- a/mod/widgets/dock/dock_widgets/object_order_widget.py
+++ b/mod/widgets/dock/dock_widgets/object_order_widget.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Object Order widget"""
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.case import Case
 from mod.tools.gui_tools import get_icon
 from mod.tools.translation_tools import __

--- a/mod/widgets/dock/dock_widgets/run_additional_parameters_dialog.py
+++ b/mod/widgets/dock/dock_widgets/run_additional_parameters_dialog.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Additional Parameters Dialog for running configuration. """
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 
 from mod.tools.translation_tools import __
 

--- a/mod/widgets/dock/dock_widgets/run_dialog.py
+++ b/mod/widgets/dock/dock_widgets/run_dialog.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Run Dialog"""
 
-from PySide2 import QtCore, QtWidgets,QtGui
+from mod.tools.qt_compat import QtCore, QtWidgets,QtGui
 from mod.constants import LINE_END
 from mod.tools.dialog_tools import warning_dialog
 from mod.tools.gui_tools import h_line_generator

--- a/mod/widgets/dock/dock_widgets/setup_plugin_dialog.py
+++ b/mod/widgets/dock/dock_widgets/setup_plugin_dialog.py
@@ -3,7 +3,7 @@
 """DesignSPHysics Setup Plugin Dialog """
 
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 
 from mod.dataobjects.case import Case
 from mod.dataobjects.configuration.application_settings import ApplicationSettings

--- a/mod/widgets/dock/dock_widgets/simulation_domain_widget.py
+++ b/mod/widgets/dock/dock_widgets/simulation_domain_widget.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.case import Case
 from mod.dataobjects.configuration.sd_position_property import SDPositionProperty
 from mod.dataobjects.configuration.simulation_domain import SimulationDomain

--- a/mod/widgets/dock/dock_widgets/surface_stl_dialog.py
+++ b/mod/widgets/dock/dock_widgets/surface_stl_dialog.py
@@ -3,7 +3,7 @@ import shutil
 from os import path, walk, chdir
 from os.path import dirname
 
-from PySide2 import QtWidgets, QtCore
+from mod.tools.qt_compat import QtWidgets, QtCore
 from mod.dataobjects.case import Case
 from mod.tools.dialog_tools import WaitDialog, warning_dialog, ok_cancel_dialog, info_dialog
 from mod.tools.executable_tools import refocus_cwd, ensure_process_is_executable_or_fail

--- a/mod/widgets/dock/postprocessing/computeforces_dialog.py
+++ b/mod/widgets/dock/postprocessing/computeforces_dialog.py
@@ -3,7 +3,7 @@
 """DesignSPHysics ComputeForces Config and Execution Dialog."""
 
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.case import Case
 from mod.dataobjects.configuration.application_settings import ApplicationSettings
 from mod.tools.post_processing_tools import computeforces_export

--- a/mod/widgets/dock/postprocessing/export_progress_dialog.py
+++ b/mod/widgets/dock/postprocessing/export_progress_dialog.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Execution Progress Dialog."""
 
-from PySide2 import QtWidgets, QtCore
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtWidgets, QtCore
+from mod.tools.qt_compat import QtCore, QtWidgets
 
 from mod.tools.translation_tools import __
 

--- a/mod/widgets/dock/postprocessing/floatinginfo_dialog.py
+++ b/mod/widgets/dock/postprocessing/floatinginfo_dialog.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics FloatingInfo configuration and execution Dialog."""
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.case import Case, mk_help_list
 from mod.dataobjects.configuration.application_settings import ApplicationSettings
 from mod.tools.post_processing_tools import floatinginfo_export

--- a/mod/widgets/dock/postprocessing/flowtool_dialog.py
+++ b/mod/widgets/dock/postprocessing/flowtool_dialog.py
@@ -4,7 +4,7 @@
 import os
 
 import FreeCAD
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.constants import FLOWBOXES_GROUP_NAME, FLOWBOXES_COLOR
 from mod.dataobjects.case import Case
 from mod.dataobjects.configuration.application_settings import ApplicationSettings

--- a/mod/widgets/dock/postprocessing/flowtool_xml_box_dialog.py
+++ b/mod/widgets/dock/postprocessing/flowtool_xml_box_dialog.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.case import Case
 from mod.tools.dialog_tools import warning_dialog
 from mod.tools.stdout_tools import debug

--- a/mod/widgets/dock/postprocessing/isosurface_dialog.py
+++ b/mod/widgets/dock/postprocessing/isosurface_dialog.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics IsoSurface Config and Execution Dialog."""
 
-from PySide2 import QtWidgets, QtCore
+from mod.tools.qt_compat import QtWidgets, QtCore
 from mod.dataobjects.case import Case, mk_help_list
 from mod.dataobjects.configuration.application_settings import ApplicationSettings
 from mod.tools.post_processing_tools import isosurface_export

--- a/mod/widgets/dock/postprocessing/measuretool_dialog.py
+++ b/mod/widgets/dock/postprocessing/measuretool_dialog.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics ComputeForces Config and Execution Dialog."""
 
-from PySide2 import QtWidgets, QtCore
+from mod.tools.qt_compat import QtWidgets, QtCore
 from mod.constants import MKFLUID_LIMIT
 from mod.dataobjects.configuration.application_settings import ApplicationSettings
 from mod.enums import ObjectType

--- a/mod/widgets/dock/postprocessing/measuretool_grid_dialog.py
+++ b/mod/widgets/dock/postprocessing/measuretool_grid_dialog.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics MeasureTool Grid Dialog """
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.case import Case
 from mod.tools.dialog_tools import warning_dialog
 from mod.tools.translation_tools import __

--- a/mod/widgets/dock/postprocessing/measuretool_points_dialog.py
+++ b/mod/widgets/dock/postprocessing/measuretool_points_dialog.py
@@ -3,7 +3,7 @@
 """DesignSPHysics ComputeForces Points configuration Dialog."""
 
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.case import Case
 from mod.tools.dialog_tools import warning_dialog
 from mod.tools.stdout_tools import debug

--- a/mod/widgets/dock/postprocessing/mk_helper_widget.py
+++ b/mod/widgets/dock/postprocessing/mk_helper_widget.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets, QtCore
+from mod.tools.qt_compat import QtWidgets, QtCore
 from mod.dataobjects.case import Case
 from mod.enums import ObjectType
 from mod.tools.freecad_tools import get_fc_object

--- a/mod/widgets/dock/postprocessing/partvtk_dialog.py
+++ b/mod/widgets/dock/postprocessing/partvtk_dialog.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics PartVTK Config and Execution Dialog."""
 
-from PySide2 import QtWidgets, QtCore
+from mod.tools.qt_compat import QtWidgets, QtCore
 from mod.dataobjects.case import Case
 from mod.dataobjects.configuration.application_settings import ApplicationSettings
 from mod.tools.post_processing_tools import partvtk_export

--- a/mod/widgets/dock/special_widgets/acceleration_input_dialog.py
+++ b/mod/widgets/dock/special_widgets/acceleration_input_dialog.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Acceleration Input Dialog."""
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.enums import ObjectType
 from mod.tools.stdout_tools import debug
 

--- a/mod/widgets/dock/special_widgets/chrono/chrono_config_dialog.py
+++ b/mod/widgets/dock/special_widgets/chrono/chrono_config_dialog.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Chrono configuration dialog."""
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.case import Case
 from mod.dataobjects.chrono.chrono_link_coulomb_damping import ChronoLinkCoulombDamping
 from mod.dataobjects.chrono.chrono_link_hinge import ChronoLinkHinge
@@ -121,7 +121,7 @@ class ChronoConfigDialog(QtWidgets.QDialog):
         self.objectlist_table.setObjectName("Chrono objects table")
         self.objectlist_table.verticalHeader().setVisible(False)
         self.objectlist_table.horizontalHeader().setVisible(False)
-        self.objectlist_table.horizontalHeader().setResizeMode(0, QtWidgets.QHeaderView.Stretch)
+        self.objectlist_table.horizontalHeader().setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
 
         self.objectlist_table.setEnabled(True)
 

--- a/mod/widgets/dock/special_widgets/chrono/chrono_object_check_options.py
+++ b/mod/widgets/dock/special_widgets/chrono/chrono_object_check_options.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Chrono Object Check Options widget."""
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 
 from mod.tools.translation_tools import __
 

--- a/mod/widgets/dock/special_widgets/chrono/link_coulombdamping_edit.py
+++ b/mod/widgets/dock/special_widgets/chrono/link_coulombdamping_edit.py
@@ -3,7 +3,7 @@
 """DesignSPHysics CoulombDamping Edit Dialog """
 
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.case import Case
 from mod.tools.dialog_tools import error_dialog
 from mod.tools.translation_tools import __

--- a/mod/widgets/dock/special_widgets/chrono/link_hinge_edit.py
+++ b/mod/widgets/dock/special_widgets/chrono/link_hinge_edit.py
@@ -3,7 +3,7 @@
 """DesignSPHysics Link Hinge Edit Dialog """
 
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.case import Case
 from mod.tools.dialog_tools import error_dialog
 from mod.tools.translation_tools import __

--- a/mod/widgets/dock/special_widgets/chrono/link_linear_spring_edit.py
+++ b/mod/widgets/dock/special_widgets/chrono/link_linear_spring_edit.py
@@ -3,7 +3,7 @@
 """DesignSPHysics LinkLinearSprint Edit Dialog """
 
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.case import Case
 from mod.tools.dialog_tools import error_dialog
 from mod.tools.translation_tools import __

--- a/mod/widgets/dock/special_widgets/chrono/link_point_line_edit.py
+++ b/mod/widgets/dock/special_widgets/chrono/link_point_line_edit.py
@@ -3,7 +3,7 @@
 """DesignSPHysics LinkPointLine Edit Dialog """
 
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 
 from mod.dataobjects.case import Case
 from mod.tools.dialog_tools import error_dialog

--- a/mod/widgets/dock/special_widgets/chrono/link_pulley_edit.py
+++ b/mod/widgets/dock/special_widgets/chrono/link_pulley_edit.py
@@ -3,7 +3,7 @@
 """DesignSPHysics Link Pulley Edit Dialog """
 
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.case import Case
 from mod.tools.dialog_tools import error_dialog
 from mod.tools.translation_tools import __

--- a/mod/widgets/dock/special_widgets/chrono/link_spheric_edit.py
+++ b/mod/widgets/dock/special_widgets/chrono/link_spheric_edit.py
@@ -3,7 +3,7 @@
 """DesignSPHysics LinkSphere Edit Widget """
 
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.case import Case
 from mod.tools.dialog_tools import error_dialog
 from mod.tools.translation_tools import __

--- a/mod/widgets/dock/special_widgets/damping/damping_box_config_dialog.py
+++ b/mod/widgets/dock/special_widgets/damping/damping_box_config_dialog.py
@@ -4,7 +4,7 @@
 
 import FreeCAD
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.constants import DIVIDER
 from mod.tools.translation_tools import __
 from mod.widgets.dock.special_widgets.damping.damping_config_dialog import DampingConfigDialog

--- a/mod/widgets/dock/special_widgets/damping/damping_config_dialog.py
+++ b/mod/widgets/dock/special_widgets/damping/damping_config_dialog.py
@@ -4,7 +4,7 @@
 
 import FreeCAD
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.tools.translation_tools import __
 from mod.widgets.custom_widgets.value_input import ValueInput
 from mod.widgets.custom_widgets.size_input import SizeInput

--- a/mod/widgets/dock/special_widgets/damping/damping_cylinder_dialog.py
+++ b/mod/widgets/dock/special_widgets/damping/damping_cylinder_dialog.py
@@ -4,7 +4,7 @@
 
 import FreeCAD
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.constants import DIVIDER
 from mod.widgets.dock.special_widgets.damping.damping_config_dialog import DampingConfigDialog
 from mod.widgets.custom_widgets.size_input import SizeInput

--- a/mod/widgets/dock/special_widgets/damping/damping_zone_config_dialog.py
+++ b/mod/widgets/dock/special_widgets/damping/damping_zone_config_dialog.py
@@ -4,7 +4,7 @@
 
 import FreeCAD
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.constants import DIVIDER
 from mod.tools.dialog_tools import error_dialog
 from mod.tools.translation_tools import __

--- a/mod/widgets/dock/special_widgets/flex_struct_dialog.py
+++ b/mod/widgets/dock/special_widgets/flex_struct_dialog.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.constants import MKFLUID_LIMIT
 from mod.dataobjects.case import Case
 from mod.dataobjects.properties.flexstruct import FlexStruct

--- a/mod/widgets/dock/special_widgets/gauges/base_gauge_dialog.py
+++ b/mod/widgets/dock/special_widgets/gauges/base_gauge_dialog.py
@@ -1,6 +1,6 @@
-from PySide2.QtWidgets import QHBoxLayout
+from mod.tools.qt_compat import QHBoxLayout
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.tools.freecad_tools import delete_object
 from mod.tools.translation_tools import __
 from mod.widgets.custom_widgets.value_input import ValueInput

--- a/mod/widgets/dock/special_widgets/gauges/flow_gauge_dialog.py
+++ b/mod/widgets/dock/special_widgets/gauges/flow_gauge_dialog.py
@@ -1,6 +1,6 @@
-from PySide2.QtWidgets import QHBoxLayout
+from mod.tools.qt_compat import QHBoxLayout
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.gauges.flow_gauge import FlowGauge
 from mod.tools.dialog_tools import warning_dialog
 from mod.tools.freecad_tools import update_flow_gauge_box

--- a/mod/widgets/dock/special_widgets/gauges/force_gauge_dialog.py
+++ b/mod/widgets/dock/special_widgets/gauges/force_gauge_dialog.py
@@ -1,6 +1,6 @@
-from PySide2.QtWidgets import QHBoxLayout
+from mod.tools.qt_compat import QHBoxLayout
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.gauges.force_gauge import ForceGauge
 from mod.tools.dialog_tools import warning_dialog
 from mod.enums import ObjectType

--- a/mod/widgets/dock/special_widgets/gauges/gauges_list_dialog.py
+++ b/mod/widgets/dock/special_widgets/gauges/gauges_list_dialog.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.constants import GAUGES_GROUP_NAME, GAUGES_COLOR
 from mod.dataobjects.case import Case
 from mod.dataobjects.gauges.force_gauge import ForceGauge

--- a/mod/widgets/dock/special_widgets/gauges/max_z_gauge_dialog.py
+++ b/mod/widgets/dock/special_widgets/gauges/max_z_gauge_dialog.py
@@ -1,6 +1,6 @@
-from PySide2.QtWidgets import QHBoxLayout
+from mod.tools.qt_compat import QHBoxLayout
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.gauges.max_z_gauge import MaxZGauge
 from mod.tools.dialog_tools import warning_dialog
 from mod.tools.freecad_tools import update_line

--- a/mod/widgets/dock/special_widgets/gauges/mesh_gauge_dialog.py
+++ b/mod/widgets/dock/special_widgets/gauges/mesh_gauge_dialog.py
@@ -1,6 +1,6 @@
-from PySide2.QtWidgets import QHBoxLayout
+from mod.tools.qt_compat import QHBoxLayout
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.gauges.mesh_gauge import MeshGauge
 from mod.tools.dialog_tools import warning_dialog
 from mod.tools.freecad_tools import update_mesh_gauge_box

--- a/mod/widgets/dock/special_widgets/gauges/swl_gauge_dialog.py
+++ b/mod/widgets/dock/special_widgets/gauges/swl_gauge_dialog.py
@@ -1,6 +1,6 @@
-from PySide2.QtWidgets import QHBoxLayout
+from mod.tools.qt_compat import QHBoxLayout
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.gauges.swl_gauge import SWLGauge
 from mod.tools.dialog_tools import warning_dialog
 from mod.tools.freecad_tools import update_line

--- a/mod/widgets/dock/special_widgets/gauges/velocity_gauge_dialog.py
+++ b/mod/widgets/dock/special_widgets/gauges/velocity_gauge_dialog.py
@@ -1,6 +1,6 @@
-from PySide2.QtWidgets import QHBoxLayout
+from mod.tools.qt_compat import QHBoxLayout
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.gauges.velocity_gauge import VelocityGauge
 from mod.tools.dialog_tools import warning_dialog
 from mod.tools.freecad_tools import update_sphere

--- a/mod/widgets/dock/special_widgets/inout/inlet_config_dialog.py
+++ b/mod/widgets/dock/special_widgets/inout/inlet_config_dialog.py
@@ -2,9 +2,9 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Inlet/Oulet Configuration Dialog """
 
-from PySide2.QtWidgets import QDialog
+from mod.tools.qt_compat import QDialog
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.case import Case
 from mod.dataobjects.inletoutlet.inlet_outlet_config import InletOutletConfig
 from mod.dataobjects.inletoutlet.inlet_outlet_zone import InletOutletZone
@@ -180,7 +180,7 @@ class InletConfigDialog(QtWidgets.QDialog):
         self.zones_groupbox_layout = QtWidgets.QVBoxLayout()
         self.io_zones_table = QtWidgets.QTableWidget()
         self.io_zones_table.setColumnCount(1)
-        self.io_zones_table.horizontalHeader().setResizeMode(QtWidgets.QHeaderView.Stretch)
+        self.io_zones_table.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
         self.io_zones_table.verticalHeader().setDefaultSectionSize(self.MINIMUM_TABLE_SECTION_HEIGHT)
         self.io_zones_table.horizontalHeader().setVisible(False)
         self.io_zones_table.verticalHeader().setVisible(False)

--- a/mod/widgets/dock/special_widgets/inout/inlet_zone_edit.py
+++ b/mod/widgets/dock/special_widgets/inout/inlet_zone_edit.py
@@ -3,7 +3,7 @@
 """DesignSPHysics Inlet Zone Configuration Dialog."""
 
 # from PySide2.QtWidgets import QVBoxLayout
-from PySide2 import QtWidgets, QtCore
+from mod.tools.qt_compat import QtWidgets, QtCore
 from mod.dataobjects.case import Case
 from mod.dataobjects.inletoutlet.inlet_outlet_zone import InletOutletZone
 from mod.enums import InletOutletElevationType, InletOutletVelocitySpecType, InletOutletVelocityType, \

--- a/mod/widgets/dock/special_widgets/inout/velocity_widgets.py
+++ b/mod/widgets/dock/special_widgets/inout/velocity_widgets.py
@@ -1,8 +1,8 @@
 import os.path
 
-from PySide2.QtCore import Signal
+from mod.tools.qt_compat import Signal
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.case import Case
 from mod.dataobjects.inletoutlet.inlet_outlet_velocity_info import InletOutletVelocityInfo
 from mod.dataobjects.inletoutlet.velocities.linear_velocity import LinearVelocity

--- a/mod/widgets/dock/special_widgets/inout/zone_generator_widgets/box_zone_generator_widget.py
+++ b/mod/widgets/dock/special_widgets/inout/zone_generator_widgets/box_zone_generator_widget.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.inletoutlet.inlet_outlet_zone_box_generator import InletOutletZoneBoxGenerator
 from mod.dataobjects.inletoutlet.inlet_outlet_zone_direction import InletOutletZone3DDirection
 from mod.dataobjects.inletoutlet.inlet_outlet_zone_rotation import InletOutletZone3DRotation

--- a/mod/widgets/dock/special_widgets/inout/zone_generator_widgets/circle_zone_generator_widget.py
+++ b/mod/widgets/dock/special_widgets/inout/zone_generator_widgets/circle_zone_generator_widget.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.inletoutlet.inlet_outlet_zone_direction import InletOutletZone3DDirection
 from mod.dataobjects.inletoutlet.inlet_outlet_zone_rotation import InletOutletZone3DRotation
 from mod.tools.translation_tools import __

--- a/mod/widgets/dock/special_widgets/inout/zone_generator_widgets/line_zone_generator_widget.py
+++ b/mod/widgets/dock/special_widgets/inout/zone_generator_widgets/line_zone_generator_widget.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.inletoutlet.inlet_outlet_zone_direction import InletOutletZone2DDirection
 from mod.dataobjects.inletoutlet.inlet_outlet_zone_line_generator import InletOutletZoneLineGenerator
 from mod.dataobjects.inletoutlet.inlet_outlet_zone_rotation import InletOutletZone2DRotation

--- a/mod/widgets/dock/special_widgets/inout/zone_generator_widgets/mk_zone_generator_widget.py
+++ b/mod/widgets/dock/special_widgets/inout/zone_generator_widgets/mk_zone_generator_widget.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.enums import InletOutletDirection, ObjectType
 from mod.tools.translation_tools import __
 from mod.widgets.dock.special_widgets.inout.zone_generator_widgets.zone_2d_direction_widget import Zone2DDirectionWidget

--- a/mod/widgets/dock/special_widgets/inout/zone_generator_widgets/zone_2d_direction_widget.py
+++ b/mod/widgets/dock/special_widgets/inout/zone_generator_widgets/zone_2d_direction_widget.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.inletoutlet.inlet_outlet_zone_direction import InletOutletZone2DDirection
 from mod.tools.translation_tools import __
 from mod.widgets.custom_widgets.value_input import ValueInput

--- a/mod/widgets/dock/special_widgets/inout/zone_generator_widgets/zone_2d_rotation_widget.py
+++ b/mod/widgets/dock/special_widgets/inout/zone_generator_widgets/zone_2d_rotation_widget.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.inletoutlet.inlet_outlet_zone_rotation import InletOutletZone2DRotation
 from mod.tools.translation_tools import __
 from mod.widgets.custom_widgets.size_input import SizeInput

--- a/mod/widgets/dock/special_widgets/inout/zone_generator_widgets/zone_3d_direction_widget.py
+++ b/mod/widgets/dock/special_widgets/inout/zone_generator_widgets/zone_3d_direction_widget.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.inletoutlet.inlet_outlet_zone_direction import InletOutletZone3DDirection
 from mod.tools.translation_tools import __
 from mod.widgets.custom_widgets.value_input import ValueInput

--- a/mod/widgets/dock/special_widgets/inout/zone_generator_widgets/zone_3d_rotation_widget.py
+++ b/mod/widgets/dock/special_widgets/inout/zone_generator_widgets/zone_3d_rotation_widget.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.inletoutlet.inlet_outlet_zone_rotation import InletOutletZone3DRotation
 from mod.tools.translation_tools import __
 from mod.widgets.custom_widgets.size_input import SizeInput

--- a/mod/widgets/dock/special_widgets/inout/zsurf_widgets.py
+++ b/mod/widgets/dock/special_widgets/inout/zsurf_widgets.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.case import Case
 from mod.tools.freecad_tools import get_fc_main_window
 from mod.tools.translation_tools import __

--- a/mod/widgets/dock/special_widgets/ml_piston_1d_config_dialog.py
+++ b/mod/widgets/dock/special_widgets/ml_piston_1d_config_dialog.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics MLPiston1D Configuration Dialog. """
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 
 from mod.tools.translation_tools import __
 from mod.tools.gui_tools import h_line_generator

--- a/mod/widgets/dock/special_widgets/ml_piston_2d_config_dialog.py
+++ b/mod/widgets/dock/special_widgets/ml_piston_2d_config_dialog.py
@@ -5,7 +5,7 @@
 import glob
 from os import path
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 
 from mod.tools.translation_tools import __
 from mod.tools.gui_tools import h_line_generator

--- a/mod/widgets/dock/special_widgets/moorings/moordynplus_body_configuration_dialog.py
+++ b/mod/widgets/dock/special_widgets/moorings/moordynplus_body_configuration_dialog.py
@@ -3,7 +3,7 @@
 """ DesignSPHysics MoorDynPlus Body Configuration Dialog. """
 
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.moorings.moordynplus.moordynplus_body import MoorDynPlusBody
 from mod.tools.gui_tools import h_line_generator
 from mod.tools.translation_tools import __

--- a/mod/widgets/dock/special_widgets/moorings/moordynplus_line_configuration_dialog.py
+++ b/mod/widgets/dock/special_widgets/moorings/moordynplus_line_configuration_dialog.py
@@ -3,7 +3,7 @@
 """ DesignSPHysics MoorDynPlus Line Configuration Dialog. """
 
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.moorings.moordynplus.moordynplus_fix_connection import MoorDynPlusFixConnection
 from mod.dataobjects.moorings.moordynplus.moordynplus_line import MoorDynPlusLine
 from mod.dataobjects.moorings.moordynplus.moordynplus_vessel_connection import MoorDynPlusVesselConnection

--- a/mod/widgets/dock/special_widgets/moorings/moordynplus_parameters_dialog.py
+++ b/mod/widgets/dock/special_widgets/moorings/moordynplus_parameters_dialog.py
@@ -4,7 +4,7 @@
 
 from uuid import UUID
 
-from PySide2 import QtWidgets, QtCore
+from mod.tools.qt_compat import QtWidgets, QtCore
 from mod.dataobjects.moorings.moordynplus.moordynplus_configuration import MoorDynPlusConfiguration
 from mod.dataobjects.moorings.moordynplus.moordynplus_line import MoorDynPlusLine
 from mod.dataobjects.moorings.moordynplus.moordynplus_line_default_configuration import MoorDynPlusLineDefaultConfiguration
@@ -196,7 +196,7 @@ class MoorDynPlusParametersDialog(QtWidgets.QDialog):
         self.body_configuration_groupbox: QtWidgets.QGroupBox = QtWidgets.QGroupBox(__("Body configuration"))
         self.body_configuration_groupbox_layout: QtWidgets.QVBoxLayout = QtWidgets.QVBoxLayout()
         self.body_configuration_table: QtWidgets.QTableWidget = QtWidgets.QTableWidget()
-        self.body_configuration_table.horizontalHeader().setResizeMode(QtWidgets.QHeaderView.Stretch)
+        self.body_configuration_table.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
         self.body_configuration_table.horizontalHeader().hide()
         self.body_configuration_table.verticalHeader().hide()
         self.body_configuration_table.setRowCount(0)
@@ -311,7 +311,7 @@ class MoorDynPlusParametersDialog(QtWidgets.QDialog):
         self.lines_table: QtWidgets.QTableWidget = QtWidgets.QTableWidget()
         self.lines_table.setRowCount(0)
         self.lines_table.setColumnCount(1)
-        self.lines_table.horizontalHeader().setResizeMode(QtWidgets.QHeaderView.Stretch)
+        self.lines_table.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
         self.lines_table.horizontalHeader().hide()
         self.lines_table.verticalHeader().hide()
         self.add_line_button: QtWidgets.QPushButton = QtWidgets.QPushButton(__("Add a new Line"))

--- a/mod/widgets/dock/special_widgets/moorings/moorings_configuration_dialog.py
+++ b/mod/widgets/dock/special_widgets/moorings/moorings_configuration_dialog.py
@@ -5,7 +5,7 @@
 from copy import deepcopy
 
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.constants import MKFLUID_LIMIT
 from mod.dataobjects.case import Case
 from mod.dataobjects.moorings.moordynplus.moordynplus_body import MoorDynPlusBody
@@ -87,7 +87,7 @@ class MooringsConfigurationDialog(QtWidgets.QDialog):
         self.floating_selection_vlayout: QtWidgets.QVBoxLayout = QtWidgets.QVBoxLayout()
         self.floating_selection_label: QtWidgets.QLabel = QtWidgets.QLabel(__("Select mks to use with moorings:"))
         self.floating_selection_table: QtWidgets.QTableWidget = QtWidgets.QTableWidget(0, 1)
-        self.floating_selection_table.horizontalHeader().setResizeMode(QtWidgets.QHeaderView.Stretch)
+        self.floating_selection_table.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
         self.floating_selection_table.horizontalHeader().hide()
         self.floating_selection_table.verticalHeader().hide()
         self.floating_selection_table.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)

--- a/mod/widgets/dock/special_widgets/outfilters/base_dialog.py
+++ b/mod/widgets/dock/special_widgets/outfilters/base_dialog.py
@@ -1,6 +1,6 @@
-from PySide2.QtWidgets import QHBoxLayout
+from mod.tools.qt_compat import QHBoxLayout
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.outparts_filter.filters import BaseFilter
 from mod.enums import FilterOperations, ObjectType
 from mod.tools.translation_tools import __

--- a/mod/widgets/dock/special_widgets/outfilters/cylinder_filter_dialog.py
+++ b/mod/widgets/dock/special_widgets/outfilters/cylinder_filter_dialog.py
@@ -1,6 +1,6 @@
-from PySide2.QtWidgets import QHBoxLayout
+from mod.tools.qt_compat import QHBoxLayout
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.outparts_filter.filters import FilterCylinder
 from mod.tools.dialog_tools import warning_dialog
 from mod.tools.freecad_tools import update_cylinder

--- a/mod/widgets/dock/special_widgets/outfilters/group_filter_dialog.py
+++ b/mod/widgets/dock/special_widgets/outfilters/group_filter_dialog.py
@@ -1,6 +1,6 @@
-from PySide2.QtWidgets import QHBoxLayout
+from mod.tools.qt_compat import QHBoxLayout
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.outparts_filter.filters import FilterGroup, FilterPos, FilterPlane, FilterSphere, FilterCylinder, \
     TypeFilter, FilterMK
 from mod.tools.dialog_tools import warning_dialog, info_dialog, ok_cancel_dialog

--- a/mod/widgets/dock/special_widgets/outfilters/mk_filter_dialog.py
+++ b/mod/widgets/dock/special_widgets/outfilters/mk_filter_dialog.py
@@ -1,6 +1,6 @@
-from PySide2.QtWidgets import QHBoxLayout
+from mod.tools.qt_compat import QHBoxLayout
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.outparts_filter.filters import FilterMK
 from mod.tools.dialog_tools import warning_dialog
 from mod.enums import ObjectType

--- a/mod/widgets/dock/special_widgets/outfilters/outparts_dialog.py
+++ b/mod/widgets/dock/special_widgets/outfilters/outparts_dialog.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.constants import OUTFILTERS_GROUP_NAME
 from mod.dataobjects.case import Case
 

--- a/mod/widgets/dock/special_widgets/outfilters/plane_filter_dialog.py
+++ b/mod/widgets/dock/special_widgets/outfilters/plane_filter_dialog.py
@@ -1,6 +1,6 @@
-from PySide2.QtWidgets import QHBoxLayout
+from mod.tools.qt_compat import QHBoxLayout
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.outparts_filter.filters import FilterPlane
 from mod.tools.dialog_tools import warning_dialog
 from mod.tools.translation_tools import __

--- a/mod/widgets/dock/special_widgets/outfilters/pos_filter_dialog.py
+++ b/mod/widgets/dock/special_widgets/outfilters/pos_filter_dialog.py
@@ -1,6 +1,6 @@
-from PySide2.QtWidgets import QHBoxLayout
+from mod.tools.qt_compat import QHBoxLayout
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.outparts_filter.filters import FilterPos
 from mod.tools.dialog_tools import warning_dialog
 from mod.tools.freecad_tools import update_box

--- a/mod/widgets/dock/special_widgets/outfilters/sphere_filter_dialog.py
+++ b/mod/widgets/dock/special_widgets/outfilters/sphere_filter_dialog.py
@@ -1,6 +1,6 @@
-from PySide2.QtWidgets import QHBoxLayout
+from mod.tools.qt_compat import QHBoxLayout
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.outparts_filter.filters import FilterSphere
 from mod.tools.dialog_tools import warning_dialog
 from mod.tools.freecad_tools import update_sphere

--- a/mod/widgets/dock/special_widgets/outfilters/type_filter_dialog.py
+++ b/mod/widgets/dock/special_widgets/outfilters/type_filter_dialog.py
@@ -1,6 +1,6 @@
-from PySide2.QtWidgets import QHBoxLayout
+from mod.tools.qt_compat import QHBoxLayout
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.outparts_filter.filters import TypeFilter
 from mod.tools.dialog_tools import warning_dialog
 from mod.tools.translation_tools import __

--- a/mod/widgets/dock/special_widgets/relaxation_zone/relaxation_zone_file_config_dialog.py
+++ b/mod/widgets/dock/special_widgets/relaxation_zone/relaxation_zone_file_config_dialog.py
@@ -4,7 +4,7 @@
 
 from os import path
 
-from PySide2 import QtWidgets, QtCore
+from mod.tools.qt_compat import QtWidgets, QtCore
 from mod.dataobjects.case import Case
 from mod.dataobjects.relaxation_zone.relaxation_zone_file import RelaxationZoneFile
 from mod.tools.translation_tools import __

--- a/mod/widgets/dock/special_widgets/relaxation_zone/relaxation_zone_irregular_config_dialog.py
+++ b/mod/widgets/dock/special_widgets/relaxation_zone/relaxation_zone_irregular_config_dialog.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Relaxation Zone Irregular Config Dialog """
 
-from PySide2 import QtWidgets, QtCore
+from mod.tools.qt_compat import QtWidgets, QtCore
 from mod.dataobjects.relaxation_zone.relaxation_zone_irregular import RelaxationZoneIrregular
 from mod.enums import IrregularSpectrum, IrregularDiscretization
 from mod.tools.translation_tools import __

--- a/mod/widgets/dock/special_widgets/relaxation_zone/relaxation_zone_regular_config_dialog.py
+++ b/mod/widgets/dock/special_widgets/relaxation_zone/relaxation_zone_regular_config_dialog.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Relaxation Zone Regular Config Dialog. """
 
-from PySide2 import QtWidgets, QtCore
+from mod.tools.qt_compat import QtWidgets, QtCore
 from mod.dataobjects.relaxation_zone.relaxation_zone_regular import RelaxationZoneRegular
 from mod.tools.translation_tools import __
 from mod.widgets.custom_widgets.value_input import ValueInput

--- a/mod/widgets/dock/special_widgets/relaxation_zone/relaxation_zone_uniform_config_dialog.py
+++ b/mod/widgets/dock/special_widgets/relaxation_zone/relaxation_zone_uniform_config_dialog.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Relaxation Zone Uniform Config Dialog. """
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.relaxation_zone.relaxation_zone_uniform import RelaxationZoneUniform
 from mod.tools.translation_tools import __
 from mod.widgets.custom_widgets.size_input import SizeInput

--- a/mod/widgets/dock/special_widgets/relaxation_zone/velocity_times_dialog.py
+++ b/mod/widgets/dock/special_widgets/relaxation_zone/velocity_times_dialog.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Velocity Times Dialog """
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 
 from mod.tools.translation_tools import __
 

--- a/mod/widgets/dock/special_widgets/special_options_selector_dialog.py
+++ b/mod/widgets/dock/special_widgets/special_options_selector_dialog.py
@@ -5,7 +5,7 @@
 import FreeCAD
 import FreeCADGui
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 
 
 from mod.tools.translation_tools import __

--- a/mod/widgets/dock/special_widgets/variable_res/bufferbox_edit_dialog.py
+++ b/mod/widgets/dock/special_widgets/variable_res/bufferbox_edit_dialog.py
@@ -1,6 +1,6 @@
-from PySide2.QtWidgets import QHBoxLayout
+from mod.tools.qt_compat import QHBoxLayout
 
-from PySide2 import QtWidgets, QtCore
+from mod.tools.qt_compat import QtWidgets, QtCore
 from mod.dataobjects.case import Case
 from mod.dataobjects.configuration.simulation_domain import SimulationDomain
 from mod.dataobjects.variable_res.bufferbox import BufferBox

--- a/mod/widgets/dock/special_widgets/variable_res/variable_res_config_dialog.py
+++ b/mod/widgets/dock/special_widgets/variable_res/variable_res_config_dialog.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.case import Case
 from mod.tools.dialog_tools import ok_cancel_dialog, error_dialog
 from mod.tools.freecad_tools import manage_vres_bufferboxes

--- a/mod/widgets/properties_dock_widget.py
+++ b/mod/widgets/properties_dock_widget.py
@@ -5,9 +5,9 @@
 import FreeCAD
 import FreeCADGui
 
-from PySide2 import QtCore, QtWidgets
-from PySide2 import QtCore, QtWidgets
-from PySide2.QtWidgets import QWidget
+from mod.tools.qt_compat import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
+from mod.tools.qt_compat import QWidget
 
 from mod.dataobjects.configuration.application_settings import ApplicationSettings
 from mod.tools.translation_tools import __

--- a/mod/widgets/properties_widgets/bound_normals_dialog.py
+++ b/mod/widgets/properties_widgets/bound_normals_dialog.py
@@ -4,7 +4,7 @@
 
 import FreeCADGui
 
-from PySide2 import QtWidgets, QtCore
+from mod.tools.qt_compat import QtWidgets, QtCore
 from mod.dataobjects.case import Case
 from mod.dataobjects.properties.bound_normals_property import BoundNormals
 from mod.tools.dialog_tools import info_dialog

--- a/mod/widgets/properties_widgets/faces_dialog.py
+++ b/mod/widgets/properties_widgets/faces_dialog.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Faces Configuration Dialog"""
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.case import Case
 from mod.dataobjects.properties.faces_property import FacesProperty
 from mod.dataobjects.properties.simulation_object import SimulationObject

--- a/mod/widgets/properties_widgets/float_state_dialog.py
+++ b/mod/widgets/properties_widgets/float_state_dialog.py
@@ -4,7 +4,7 @@
 
 import FreeCADGui
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.case import Case
 from mod.dataobjects.properties.float_property import FloatProperty
 from mod.tools.dialog_tools import info_dialog

--- a/mod/widgets/properties_widgets/initials_dialog.py
+++ b/mod/widgets/properties_widgets/initials_dialog.py
@@ -5,7 +5,7 @@
 import FreeCADGui
 
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.case import Case
 from mod.dataobjects.properties.initials_property import InitialsProperty
 from mod.tools.dialog_tools import info_dialog

--- a/mod/widgets/properties_widgets/material_dialog.py
+++ b/mod/widgets/properties_widgets/material_dialog.py
@@ -3,7 +3,7 @@
 """DesignSPHysics Faces Configuration Dialog"""
 
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.case import Case
 from mod.dataobjects.properties.mk_based_properties import MKBasedProperties
 from mod.dataobjects.properties.simulation_object import SimulationObject

--- a/mod/widgets/properties_widgets/mdbc_dialog.py
+++ b/mod/widgets/properties_widgets/mdbc_dialog.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.case import Case
 from mod.dataobjects.properties.simulation_object import SimulationObject
 from mod.tools.translation_tools import __

--- a/mod/widgets/properties_widgets/motion/acc_circular_motion_timeline.py
+++ b/mod/widgets/properties_widgets/motion/acc_circular_motion_timeline.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Accelerated Circular Motion Timeline widget"""
 
-from PySide2 import QtWidgets, QtCore
+from mod.tools.qt_compat import QtWidgets, QtCore
 from mod.dataobjects.motion.acc_cir_motion import AccCirMotion
 from mod.tools.gui_tools import get_icon
 from mod.tools.translation_tools import __

--- a/mod/widgets/properties_widgets/motion/acc_rectilinear_motion_timeline.py
+++ b/mod/widgets/properties_widgets/motion/acc_rectilinear_motion_timeline.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Accelerated Rectilinear Motion widget"""
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.motion.acc_rect_motion import AccRectMotion
 from mod.tools.gui_tools import get_icon
 from mod.tools.translation_tools import __

--- a/mod/widgets/properties_widgets/motion/acc_rotational_motion_timeline.py
+++ b/mod/widgets/properties_widgets/motion/acc_rotational_motion_timeline.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Accelerated Rotation Motion widget"""
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.motion.acc_rot_motion import AccRotMotion
 from mod.tools.gui_tools import get_icon
 from mod.tools.translation_tools import __

--- a/mod/widgets/properties_widgets/motion/adv_rotation_file_motion_timeline.py
+++ b/mod/widgets/properties_widgets/motion/adv_rotation_file_motion_timeline.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics File Based Motion Timeline Widget. """
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.case import Case
 from mod.dataobjects.motion.file_gen import FileGen
 from mod.dataobjects.motion.rotate_adv_file_gen import RotateAdvFileGen

--- a/mod/widgets/properties_widgets/motion/cir_sinu_motion_timeline.py
+++ b/mod/widgets/properties_widgets/motion/cir_sinu_motion_timeline.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Sinusoidal Circular Motion widget."""
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.motion.cir_sinu_motion import CirSinuMotion
 from mod.tools.gui_tools import get_icon
 from mod.tools.translation_tools import __

--- a/mod/widgets/properties_widgets/motion/file_motion_timeline.py
+++ b/mod/widgets/properties_widgets/motion/file_motion_timeline.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics File Based Motion Timeline Widget. """
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.case import Case
 from mod.dataobjects.motion.file_gen import FileGen
 from mod.functions import make_float, make_int

--- a/mod/widgets/properties_widgets/motion/focused_piston_wave_motion_timeline.py
+++ b/mod/widgets/properties_widgets/motion/focused_piston_wave_motion_timeline.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Focused Piston Wave Motion Timeline Widget"""
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.motion.focused_piston_wave_gen import FocusedPistonWaveGen
 from mod.enums import IrregularSpectrum, IrregularDiscretization
 from mod.functions import make_float

--- a/mod/widgets/properties_widgets/motion/irregular_flap_wave_motion_timeline.py
+++ b/mod/widgets/properties_widgets/motion/irregular_flap_wave_motion_timeline.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Irregular Flap Wave Motion timeline widget."""
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.motion.irregular_flap_wave_gen import IrregularFlapWaveGen
 from mod.enums import IrregularDiscretization, IrregularSpectrum
 from mod.functions import make_float

--- a/mod/widgets/properties_widgets/motion/irregular_piston_wave_motion_timeline.py
+++ b/mod/widgets/properties_widgets/motion/irregular_piston_wave_motion_timeline.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Irregular Piston Wave Motion Timeline Widget"""
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.motion.awas import AWAS
 from mod.dataobjects.motion.awas_correction import AWASCorrection
 from mod.dataobjects.motion.irregular_piston_wave_gen import IrregularPistonWaveGen

--- a/mod/widgets/properties_widgets/motion/motion_timeline.py
+++ b/mod/widgets/properties_widgets/motion/motion_timeline.py
@@ -1,5 +1,5 @@
 
-from PySide2 import QtWidgets, QtCore
+from mod.tools.qt_compat import QtWidgets, QtCore
 from mod.tools.dialog_tools import warning_dialog
 
 

--- a/mod/widgets/properties_widgets/motion/movement_actions.py
+++ b/mod/widgets/properties_widgets/motion/movement_actions.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Movement Actions Widget. """
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.tools.gui_tools import get_icon
 from mod.tools.translation_tools import __
 

--- a/mod/widgets/properties_widgets/motion/movement_dialog.py
+++ b/mod/widgets/properties_widgets/motion/movement_dialog.py
@@ -4,7 +4,7 @@
 
 import FreeCADGui
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.case import Case
 from mod.dataobjects.motion.acc_cir_motion import AccCirMotion
 from mod.dataobjects.motion.acc_rect_motion import AccRectMotion
@@ -133,9 +133,9 @@ class MovementDialog(QtWidgets.QDialog):
         self.movement_list_table = QtWidgets.QTableWidget(1, 2)
         self.movement_list_table.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectItems)
         self.movement_list_table.setSelectionMode(QtWidgets.QAbstractItemView.SingleSelection)
-        self.movement_list_table.horizontalHeader().setResizeMode(QtWidgets.QHeaderView.Stretch)
-        self.movement_list_table.horizontalHeader().setResizeMode(0, QtWidgets.QHeaderView.Stretch)
-        self.movement_list_table.horizontalHeader().setResizeMode(1, QtWidgets.QHeaderView.ResizeToContents)
+        self.movement_list_table.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
+        self.movement_list_table.horizontalHeader().setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
+        self.movement_list_table.horizontalHeader().setSectionResizeMode(1, QtWidgets.QHeaderView.ResizeToContents)
 
         self.movement_list_table.verticalHeader().setVisible(False)
         self.movement_list_table.horizontalHeader().setVisible(False)
@@ -149,8 +149,8 @@ class MovementDialog(QtWidgets.QDialog):
         self.timeline_groupbox.setMinimumWidth(720)
 
         self.timeline_list_table = QtWidgets.QTableWidget(0, 1)
-        self.timeline_list_table.horizontalHeader().setResizeMode(QtWidgets.QHeaderView.Stretch)
-        self.timeline_list_table.verticalHeader().setResizeMode(QtWidgets.QHeaderView.ResizeToContents)
+        self.timeline_list_table.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
+        self.timeline_list_table.verticalHeader().setSectionResizeMode(QtWidgets.QHeaderView.ResizeToContents)
         self.timeline_list_table.verticalHeader().setVisible(False)
         self.timeline_list_table.horizontalHeader().setVisible(False)
         self.timeline_list_table.resizeRowsToContents()
@@ -166,7 +166,7 @@ class MovementDialog(QtWidgets.QDialog):
 
 
         self.actions_groupbox_table = QtWidgets.QTableWidget(0, 1)
-        self.actions_groupbox_table.horizontalHeader().setResizeMode(QtWidgets.QHeaderView.Stretch)
+        self.actions_groupbox_table.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
         self.actions_groupbox_table.verticalHeader().setVisible(False)
         self.actions_groupbox_table.horizontalHeader().setVisible(False)
 

--- a/mod/widgets/properties_widgets/motion/movement_timeline_placeholder.py
+++ b/mod/widgets/properties_widgets/motion/movement_timeline_placeholder.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Movement Timeline Placeholder Widget """
 
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 
 from mod.tools.translation_tools import __
 

--- a/mod/widgets/properties_widgets/motion/path_file_motion_timeline.py
+++ b/mod/widgets/properties_widgets/motion/path_file_motion_timeline.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics File Based Motion Timeline Widget. """
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.case import Case
 from mod.dataobjects.motion.file_gen import FileGen
 from mod.dataobjects.motion.path_file_gen import PathFileGen

--- a/mod/widgets/properties_widgets/motion/rect_sinu_motion_timeline.py
+++ b/mod/widgets/properties_widgets/motion/rect_sinu_motion_timeline.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Rectilinear Sinusoidal Motion Timeline """
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.motion.rect_sinu_motion import RectSinuMotion
 from mod.tools.gui_tools import get_icon
 from mod.tools.translation_tools import __

--- a/mod/widgets/properties_widgets/motion/rectilinear_motion_timeline.py
+++ b/mod/widgets/properties_widgets/motion/rectilinear_motion_timeline.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Rectilinear Motion Timeline Widget """
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.motion.rect_motion import RectMotion
 from mod.tools.gui_tools import get_icon
 from mod.tools.translation_tools import __

--- a/mod/widgets/properties_widgets/motion/regular_flap_wave_motion_timeline.py
+++ b/mod/widgets/properties_widgets/motion/regular_flap_wave_motion_timeline.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Regular Flap Wave Motion Timeline Widget """
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.motion.regular_flap_wave_gen import RegularFlapWaveGen
 from mod.tools.gui_tools import h_line_generator
 from mod.tools.translation_tools import __

--- a/mod/widgets/properties_widgets/motion/regular_piston_wave_motion_timeline.py
+++ b/mod/widgets/properties_widgets/motion/regular_piston_wave_motion_timeline.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Regular Piston Wave Motion Timeline Widget """
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.motion.awas import AWAS
 from mod.dataobjects.motion.awas_correction import AWASCorrection
 from mod.dataobjects.motion.regular_piston_wave_gen import RegularPistonWaveGen

--- a/mod/widgets/properties_widgets/motion/rot_sinu_motion_timeline.py
+++ b/mod/widgets/properties_widgets/motion/rot_sinu_motion_timeline.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Rotationial Sinusoidal Motion Timeline Widget. """
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.motion.rot_sinu_motion import RotSinuMotion
 from mod.tools.gui_tools import get_icon
 from mod.tools.translation_tools import __

--- a/mod/widgets/properties_widgets/motion/rotation_file_motion_timeline.py
+++ b/mod/widgets/properties_widgets/motion/rotation_file_motion_timeline.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics """
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.case import Case
 from mod.dataobjects.motion.rotation_file_gen import RotationFileGen
 from mod.tools.gui_tools import h_line_generator

--- a/mod/widgets/properties_widgets/motion/rotational_motion_timeline.py
+++ b/mod/widgets/properties_widgets/motion/rotational_motion_timeline.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Rotational Motion Timeline Widget """
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.motion.rot_motion import RotMotion
 from mod.tools.gui_tools import get_icon
 from mod.tools.translation_tools import __

--- a/mod/widgets/properties_widgets/motion/solitary_piston_wave_motion_timeline.py
+++ b/mod/widgets/properties_widgets/motion/solitary_piston_wave_motion_timeline.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Soliotary Piston Wave Motion Timeline Widget """
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.motion.awas import AWAS
 from mod.dataobjects.motion.awas_correction import AWASCorrection
 from mod.dataobjects.motion.solitary_piston_wave_gen import SolitaryPistonWaveGen

--- a/mod/widgets/properties_widgets/motion/wait_motion_timeline.py
+++ b/mod/widgets/properties_widgets/motion/wait_motion_timeline.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Wait Motion Timeline Widget """
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.dataobjects.motion.wait_motion import WaitMotion
 from mod.tools.gui_tools import get_icon
 from mod.tools.translation_tools import __

--- a/mod/widgets/properties_widgets/motion/wave_movement_actions.py
+++ b/mod/widgets/properties_widgets/motion/wave_movement_actions.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """DesignSPHysics Wave Movement Actions Widget. """
 
-from PySide2 import QtCore, QtWidgets
+from mod.tools.qt_compat import QtCore, QtWidgets
 from mod.tools.gui_tools import get_icon
 from mod.tools.translation_tools import __
 

--- a/mod/widgets/properties_widgets/sim_object_dialog.py
+++ b/mod/widgets/properties_widgets/sim_object_dialog.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets
+from mod.tools.qt_compat import QtWidgets
 from mod.dataobjects.properties.simulation_object import SimulationObject
 from mod.tools.freecad_tools import get_fc_object
 from mod.tools.translation_tools import __


### PR DESCRIPTION
Summary
- Add Qt compatibility layer to support PySide6 with fallback to PySide2.
- Migrate module imports to the compatibility layer.
- Fix Qt6 runtime issues (QHeaderView resize API, pixmap type in logo widget).
- Fix movement dialog indentation issue discovered during FreeCAD 1.1 tests.
- Suppress harmless Qt geometry warnings in startup macro.

Validation
- Plugin UI loads in FreeCAD 1.1.
- Main dock and object/properties panes are visible.
- No syntax errors reported after migration.